### PR TITLE
Fixes

### DIFF
--- a/core/src/components/decorate-external-refs/decorate-external-refs.scss
+++ b/core/src/components/decorate-external-refs/decorate-external-refs.scss
@@ -1,6 +1,7 @@
 @use "sass:meta";
 
 .la-decorate-external-refs__popup {
+  position: relative;
   @include meta.load-css("~tippy.js/dist/tippy.css");
   @include meta.load-css("~tippy.js/themes/light-border.css");
   @include meta.load-css("../../styles/tippy");

--- a/core/src/components/decorate-internal-refs/decorate-internal-refs.scss
+++ b/core/src/components/decorate-internal-refs/decorate-internal-refs.scss
@@ -1,6 +1,7 @@
 @use "sass:meta";
 
 .la-decorate-internal-refs__popup {
+  position: relative;
   @include meta.load-css("~tippy.js/dist/tippy.css");
   @include meta.load-css("~tippy.js/themes/light-border.css");
   @include meta.load-css("../../styles/tippy");

--- a/core/src/components/decorate-terms/decorate-terms.scss
+++ b/core/src/components/decorate-terms/decorate-terms.scss
@@ -1,6 +1,7 @@
 @use "sass:meta";
 
 .la-decorate-terms__popup {
+  position: relative;
   @include meta.load-css("~tippy.js/dist/tippy.css");
   @include meta.load-css("~tippy.js/themes/light-border.css");
   @include meta.load-css("../../styles/tippy");

--- a/core/src/components/gutter/gutter.scss
+++ b/core/src/components/gutter/gutter.scss
@@ -32,5 +32,6 @@ la-gutter > la-gutter-item {
 
   &[active] {
     left: $la-gutter-padding;
+    z-index: 3;
   }
 }


### PR DESCRIPTION
* popups must have position: relative - otherwise they don't always show up correctly - see https://github.com/laws-africa/legislation-reader/blob/main/reader/templates/reader/expression_detail.html#L19
* active gutter item must have slightly higher z-index - this means content (eg. dropdowns) that overflow the main item will show above other gutter items

![image](https://github.com/laws-africa/law-widgets/assets/4178542/4ab0ffaf-ac97-438a-bc43-e189cf67e8ba)

