### PR TITLE
when a complex definition has been marked up with a blockContainer, show the whole definition in the pop-up

### DIFF
--- a/core/src/components/decorate-terms/decorate-terms.tsx
+++ b/core/src/components/decorate-terms/decorate-terms.tsx
@@ -11,7 +11,7 @@ import { AkomaNtosoTarget } from '../../utils/linking';
 export class DecorateTerms {
   // The akn content element being decorated
   protected akomaNtosoElement?: HTMLElement | null;
-  protected defnContainers = '.akn-p, .akn-subsection, .akn-section, .akn-blockList';
+  protected defnContainers = '.akn-p, .akn-subsection, .akn-section, .akn-blockList, .akn-blockContainer';
 
   protected tippies: Tippy[] = [];
   protected tippyContainer?: HTMLElement;


### PR DESCRIPTION
In this example from https://lawlibrary.org.za/akn/za/act/1962/58/eng@2022-03-01#chp_II__part_I__sec_8G, there is a further proviso.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/84df3399-6857-485d-9c10-7f70899cf981" />
